### PR TITLE
orderBy should not allow to sort on string

### DIFF
--- a/src/ng/filter/orderBy.js
+++ b/src/ng/filter/orderBy.js
@@ -177,7 +177,7 @@ orderByFilter.$inject = ['$parse'];
 function orderByFilter($parse) {
   return function(array, sortPredicate, reverseOrder) {
 
-    if (!(isArrayLike(array))) return array;
+    if (isString(array) || !isArrayLike(array)) return array;
 
     if (!isArray(sortPredicate)) { sortPredicate = [sortPredicate]; }
     if (sortPredicate.length === 0) { sortPredicate = ['+']; }


### PR DESCRIPTION
Currently if you sort `'hello' | orderBy`, it return ["e","h","l","l","o"], result does not make sense.
Instead it should be `hello` without sorted, or `ehllo` sorted as string.

This PR return orderBy return `hello` without sorting for string.